### PR TITLE
Device-write efficiency improvements

### DIFF
--- a/src/libcxi.c
+++ b/src/libcxi.c
@@ -37,9 +37,11 @@
  * @return On success, 0. Else, negative errno.
  * @note This function has been modified to improve readability and efficiency.
  * - Use ssize_t for rc:
- * 		The write system call returns a ssize_t, which should be matched for type consistency.
+ * 		The write system call returns a ssize_t, 
+ * 		which should be matched for type consistency.
  * - Combine conditions for readability and efficiency:
- * 	  By handling negative values (rc < 0) first, the condition rc != len is simpler and only applies to successful writes.
+ * 	  By handling negative values (rc < 0) first, 
+ * 	  the condition rc != len is simpler and only applies to successful writes.
  */
 static int device_write(const struct cxil_dev_priv *dev,
 						const void *cmd, size_t len) 

--- a/src/libcxi.c
+++ b/src/libcxi.c
@@ -35,22 +35,26 @@
  * @param cmd Command pointer
  * @param len Length of command
  * @return On success, 0. Else, negative errno.
+ * @note This function has been modified to improve readability and efficiency.
+ * - Use ssize_t for rc:
+ * 		The write system call returns a ssize_t, which should be matched for type consistency.
+ * - Combine conditions for readability and efficiency:
+ * 	  By handling negative values (rc < 0) first, the condition rc != len is simpler and only applies to successful writes.
  */
 static int device_write(const struct cxil_dev_priv *dev,
-			const void *cmd, size_t len)
+						const void *cmd, size_t len) 
 {
-	int rc;
+    ssize_t rc = write(dev->fd, cmd, len);
 
-	rc = write(dev->fd, cmd, len);
-	if (rc != len) {
-		if (rc < 0)
-			return -errno;
+    if (rc < 0) {
+        return -errno; // Return the negative error code directly.
+    }
 
-		/* Truncated writes shouldn't occur. Thus, treat as an error. */
-		return -EIO;
-	}
+    if ((size_t)rc != len) {
+        return -EIO; // Handle truncated writes as an error.
+    }
 
-	return 0;
+    return 0; // Success.
 }
 
 /* Open a CXI Device */


### PR DESCRIPTION
### Description
    Improve device write efficiency.
    device_write currently does unnecessary type conversion for rc to int, and has redundant checks increasing branching.

This version allows early return, more efficient error handling, and unnecessary type conversion.

We do cast rc to size_t, but a cast is effectively free from a performance standpoint and we did the check to see if it was a negative value beforehand anyway.

### Design Documents
- None

### Related JIRAs
- N/A

### Risk
LOW - The function has the same core functionality, it is only more efficient.

### Tests
Unable to test - Code inspection only. Highly recommend testing.
