### PR TITLE
remove unneeded error reporting

### DIFF
--- a/src/libcxi.c
+++ b/src/libcxi.c
@@ -950,7 +950,6 @@ CXIL_API int cxil_map(struct cxil_lni *lni, void *va, size_t len,
 	return 0;
 
 err_write:
-	fprintf(stderr, "cxil_map: write error\n");
 	if ((flags & (CXI_MAP_PIN | CXI_MAP_DEVICE)) == CXI_MAP_PIN)
 		cxil_dofork_range(va, len);
 err_dontfork:

--- a/src/libcxi.c
+++ b/src/libcxi.c
@@ -1165,7 +1165,6 @@ CXIL_API int cxil_map(struct cxil_lni *lni, void *va, size_t len,
 	return 0;
 
 err_write:
-	fprintf(stderr, "cxil_map: write error\n");
 	if ((flags & (CXI_MAP_PIN | CXI_MAP_DEVICE)) == CXI_MAP_PIN)
 		cxil_dofork_range(va, len);
 err_dontfork:


### PR DESCRIPTION
### Description

This code path returns error in the return code, and libfabric's CXI provider will now retry read-only regions.  Silence this no longer needed fprintf

### Design Documents
    none

### Related JIRAs
    Uh.. maybe this one?  https://jira-pro.it.hpe.com:8443/browse/NETCASSINI-7215

### Risk
    I guess someone might like the error message?

### Tests
    none
